### PR TITLE
Add [skip ci] to changelog commits

### DIFF
--- a/changelog-pr.py
+++ b/changelog-pr.py
@@ -109,8 +109,9 @@ class ChangelogCIBase:
         subprocess.run(['ssh', '-T', 'git@github.com'])
 
         subprocess.run(['git', 'add', self.filename])
+        # [skip ci] instructs Buildkite to ignore the commit and not create a build.
         subprocess.run(
-            ['git', 'commit', '-m', '(Changelog PR) Added Changelog']
+            ['git', 'commit', '-m', '(Changelog PR) Added Changelog', '-m', '[skip ci]']
         )
         subprocess.run(
             ['git', 'push', '-u', 'origin', self.current_branch]


### PR DESCRIPTION
Changelog commits were causing a redundant buildkite build after the merge commit. This change eliminates these extra builds.